### PR TITLE
電話番号ページ、お届け先ページ

### DIFF
--- a/app/views/signup/address.html.haml
+++ b/app/views/signup/address.html.haml
@@ -3,42 +3,42 @@
   .signup-main
     .signup-panel
       %h2.signup-panel__title 発送元・お届け先住所入力
-      = form_for do |f|
+      = form_with do |f|
         .signup-panel__insert
           .signup-inner
             .signup-form
               .signup-form__label お名前
-              %span.signup-form__require 必須
+              %span.require 必須
               = f.text_field :collum, class:"input-default", placeholder: "例) 山田"
               = f.text_field :collum, class:"input-default", placeholder: "例) 彩"
             .signup-form
               .signup-form__label お名前カナ
-              %span.signup-form__require 必須
+              %span.require 必須
               = f.email_field :collum, class:"input-default", placeholder:"例) ヤマダ"
               = f.email_field :collum, class:"input-default", placeholder:"例）アヤ"
             .signup-form
               .signup-form__label  郵便番号
-              %span.signup-form__require 必須
+              %span.require 必須
               = f.password_field  :post_code, class:"input-default", placeholder:"例)123-4567"
             .signup-form
               .signup-form__label 都道府県
-              %span.signup-form__require 必須
+              %span.require 必須
               = f.text_field :prefectures, class:"input-default", placeholder: "例) 神奈川県"
             .signup-form
               .signup-form__label 市区町村
-              %span.signup-form__require 必須
+              %span.require 必須
               = f.text_field :city, class:"input-default", placeholder: "例) 横浜市緑区"
             .signup-form
               .signup-form__label 番地
-              %span.signup-form__require 必須
+              %span.require 必須
               = f.text_field :address, class:"input-default", placeholder: "例) 青山1-1-1"
             .signup-form
               .signup-form__label 建物名
-              %span.signup-form__require--grey 任意
+              %span.arbitrary 任意
               = f.text_field :building_name, class:"input-default", placeholder: "例) 柳ビル103"
             .signup-form
               .signup-form__label 電話
-              %span.signup-form__require--grey 任意
+              %span.arbitrary 任意
               = f.text_field :collom, class:"input-default", placeholder: "例) 09012345678"
             .signup-form
               .signup-form

--- a/app/views/signup/address.html.haml
+++ b/app/views/signup/address.html.haml
@@ -1,0 +1,47 @@
+.signup-container
+  =render 'shared/sub-header'
+  .signup-main
+    .signup-panel
+      %h2.signup-panel__title 発送元・お届け先住所入力
+      = form_for do |f|
+        .signup-panel__insert
+          .signup-inner
+            .signup-form
+              .signup-form__label お名前
+              %span.signup-form__require 必須
+              = f.text_field :collum, class:"input-default", placeholder: "例) 山田"
+              = f.text_field :collum, class:"input-default", placeholder: "例) 彩"
+            .signup-form
+              .signup-form__label お名前カナ
+              %span.signup-form__require 必須
+              = f.email_field :collum, class:"input-default", placeholder:"例) ヤマダ"
+              = f.email_field :collum, class:"input-default", placeholder:"例）アヤ"
+            .signup-form
+              .signup-form__label  郵便番号
+              %span.signup-form__require 必須
+              = f.password_field  :post_code, class:"input-default", placeholder:"例)123-4567"
+            .signup-form
+              .signup-form__label 都道府県
+              %span.signup-form__require 必須
+              = f.text_field :prefectures, class:"input-default", placeholder: "例) 神奈川県"
+            .signup-form
+              .signup-form__label 市区町村
+              %span.signup-form__require 必須
+              = f.text_field :city, class:"input-default", placeholder: "例) 横浜市緑区"
+            .signup-form
+              .signup-form__label 番地
+              %span.signup-form__require 必須
+              = f.text_field :address, class:"input-default", placeholder: "例) 青山1-1-1"
+            .signup-form
+              .signup-form__label 建物名
+              %span.signup-form__require--grey 任意
+              = f.text_field :building_name, class:"input-default", placeholder: "例) 柳ビル103"
+            .signup-form
+              .signup-form__label 電話
+              %span.signup-form__require--grey 任意
+              = f.text_field :collom, class:"input-default", placeholder: "例) 09012345678"
+            .signup-form
+              .signup-form
+              = f.submit "次へ進む", class: 'signup-btn--red'  
+
+  =render 'shared/sub-footer'

--- a/app/views/signup/tel_no.html.haml
+++ b/app/views/signup/tel_no.html.haml
@@ -3,7 +3,7 @@
   .signup-main
     .signup-panel
       %h2.signup-panel__title 電話番号登録
-      = form_for do |f|
+      = form_with @user do |f|
         .signup-panel__insert
           .signup-inner
             .signup-form

--- a/app/views/signup/tel_no.html.haml
+++ b/app/views/signup/tel_no.html.haml
@@ -1,0 +1,18 @@
+.signup-container
+  =render 'shared/sub-header'
+  .signup-main
+    .signup-panel
+      %h2.signup-panel__title 電話番号登録
+      = form_for do |f|
+        .signup-panel__insert
+          .signup-inner
+            .signup-form
+              .signup-form__label 携帯電話の番号
+              = f.text_field :tel_no, class:"input-default", placeholder: "例) メルカリ太郎"
+              .signup-form
+                %p.signup-text 
+                  本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用するして認証を行います。
+              = f.submit "次へ進む", class: 'signup-btn--red'
+              %p.signup-text 
+                ※電話番号は本人確認や不正利用防止のため利用しています。他のユーザーに公開されることはありません。
+  =render 'shared/sub-footer'


### PR DESCRIPTION
# what
電話番号ページ、配送先、お届け先入力ページの実装

電話番号
[![Image from Gyazo](https://i.gyazo.com/49af6143deab29e94e51d18b073a93e4.png)](https://gyazo.com/49af6143deab29e94e51d18b073a93e4)

発送元・お届け先入力ページ
[![Image from Gyazo](https://i.gyazo.com/3e2587ee7e32f83c763fdb3d5418f8a5.png)](https://gyazo.com/3e2587ee7e32f83c763fdb3d5418f8a5)
# why
商品出品機能、マイページ機能実装のため、最低限のユーザ登録機能を実装する。