### PR TITLE
ユーザーマイページ・プロフィール編集画面のバックエンド

### DIFF
--- a/app/assets/stylesheets/modules/_mixin.scss
+++ b/app/assets/stylesheets/modules/_mixin.scss
@@ -47,11 +47,4 @@
   font-size: 12px;
   vertical-align: top;
   float: left;
-}
-
-/* placeholderの色指定 */
-@mixin placeholder($color) {
-  &::placeholder {
-    color: $color;
-  }
 } 

--- a/app/assets/stylesheets/modules/_mixin.scss
+++ b/app/assets/stylesheets/modules/_mixin.scss
@@ -48,3 +48,10 @@
   vertical-align: top;
   float: left;
 }
+
+/* placeholderの色指定 */
+@mixin placeholder($color) {
+  &::placeholder {
+    color: $color;
+  }
+} 

--- a/app/assets/stylesheets/users/_edit.scss
+++ b/app/assets/stylesheets/users/_edit.scss
@@ -52,7 +52,6 @@
             line-height: 1.5;
             font-size: 16px;
             box-sizing: border-box;
-            @include placeholder(#000);
 
             input{
               outline: 0;

--- a/app/assets/stylesheets/users/_edit.scss
+++ b/app/assets/stylesheets/users/_edit.scss
@@ -52,6 +52,7 @@
             line-height: 1.5;
             font-size: 16px;
             box-sizing: border-box;
+            @include placeholder(#000);
 
             input{
               outline: 0;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,13 +5,17 @@ class UsersController < ApplicationController
   end
 
   def edit
-    @user = User.find(params[:id])
+    @user = find_user_by_id
   end
 
   def update
-    user = User.find(params[:id])
-    user.update(user_params)
-
+    @user = find_user_by_id
+    @user.update(user_params)
+      if @user.save
+        redirect_to edit_user_path
+      else
+        redirect_to edit_user_path
+      end
   end
 
 
@@ -20,6 +24,10 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:nickname, :profile)
+  end
+
+  def find_user_by_id
+    User.find(params[:id])
   end
 
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user
+  before_action :set_user, only: [:edit, :update]
 
   def index
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,21 +1,20 @@
 class UsersController < ApplicationController
+  before_action :set_user
 
   def index
 
   end
 
   def edit
-    @user = find_user_by_id
+    
   end
 
   def update
-    @user = find_user_by_id
-    @user.update(user_params)
-      if @user.save
-        redirect_to edit_user_path
-      else
-        redirect_to edit_user_path
-      end
+    if @user.update(user_params)
+      redirect_to edit_user_path
+    else
+      redirect_to edit_user_path
+    end
   end
 
 
@@ -26,8 +25,8 @@ class UsersController < ApplicationController
     params.require(:user).permit(:nickname, :profile)
   end
 
-  def find_user_by_id
-    User.find(params[:id])
+  def set_user
+    @user =User.find(params[:id])
   end
 
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,13 +1,26 @@
 class UsersController < ApplicationController
 
   def index
-    
+
   end
 
   def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    user = User.find(params[:id])
+    user.update(user_params)
 
   end
 
+
+
+  private
+
+  def user_params
+    params.require(:user).permit(:nickname, :profile)
+  end
 
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,6 @@ class User < ApplicationRecord
   # has_many :ratings, through: :rates, source: :rated_user
   # has_one :send_address
   # has_one :real_address
+
+  validates :nickname, presence: true
 end

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -2,7 +2,7 @@
   .side-bar__mypage-nav
     %ul.side-bar__mypage-nav__list
       %li
-        = link_to  "#", class: "mypage-nav-list-item" do
+        = link_to users_path(current_user), class: "mypage-nav-list-item" do
           マイページ
           = icon 'fas', 'angle-right', class: 'icon-arrow-right'
       %li
@@ -69,7 +69,7 @@
     %ul.side-bar__mypage-nav__list
       %li
         = link_to  edit_user_path(current_user), class: "mypage-nav-list-item" do
-          プロティール
+          プロフィール
           = icon 'fas','angle-right', class: 'icon-arrow-right'
       %li
         = link_to  "#", class: "mypage-nav-list-item" do

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -3,15 +3,13 @@
     .profile
       .profile__head
         プロフィール
-      = form_with url: users_path, method: :post do |f|
+      = form_with model: @user, local: true  do |f|
         .setting-profile-icon
           %figure
             %img
-          = f.text_field :name, class: "input-default"
+          = f.text_field :nickname, class: "input-default",placeholder: current_user.nickname
         .setting-profile-content
-          = f.text_area :profile, class: "textarea-default"
+          = f.text_area :profile, class: "textarea-default", placeholder: "例）こんにちは！ご覧いただきありがとうございます。気持ちよくお取引出来るよう心がけていますので、よろしくお願いします！！"
           = f.submit "変更する", class: "btn-default btn-red"
 
   = render "shared/side_bar"
-
-    

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -7,7 +7,7 @@
         .setting-profile-icon
           %figure
             %img
-          = f.text_field :nickname, class: "input-default",placeholder: current_user.nickname
+          = f.text_field :nickname, class: "input-default",placeholder: "例）たっちゃん"
         .setting-profile-content
           = f.text_area :profile, class: "textarea-default", placeholder: "例）こんにちは！ご覧いただきありがとうございます。気持ちよくお取引出来るよう心がけていますので、よろしくお願いします！！"
           = f.submit "変更する", class: "btn-default btn-red"

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -4,14 +4,14 @@
       %a.mypage-user__link
         %img.mypage-user__link__icon
         .mypage-user__link__name
-          user_name
+          = current_user.nickname
         .mypage-user__link__rating
           .mypage-user__link__rating--left
             評価
             %span.left-count
               0
           .mypage-user__link__rating--right
-            出店数
+            出品数
             %span.right-count
               0
     .information

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,6 @@ Rails.application.routes.draw do
   end
   
   resources :items, only: [:new, :show, :create]
-  resources :users, only: [:index, :edit]
+  resources :users, only: [:index, :edit, :update]
 
 end


### PR DESCRIPTION
# What

・ユーザーマイページ・プロフィール編集の画面をDBから紐ずけて表示する。
・プロフィール編集の画面上でユーザーの情報をDBに編集・保存出来る状態にする。

#  Why

・ユーザーがプロフィールの内容を編集出来るようにするため。