### PR TITLE
ユーザの出品商品一覧画面_Lv1

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,4 +14,3 @@
 //= require jquery_ujs
 //= require_tree .
 //= require activestorage
-//= require turbolinks

--- a/app/assets/javascripts/users/sell_items.js
+++ b/app/assets/javascripts/users/sell_items.js
@@ -1,0 +1,17 @@
+$(function(){
+  
+  var href = location.pathname;
+  var user_url = "/user"
+
+  if (href.indexOf(user_url) === 0) {
+    
+    if (href == "/users/selling_items"){
+      $("#selling-tab").addClass("active");
+      $("#selling-items").addClass("active-items");
+    }
+    if (href == "/users/sold_items"){
+      $("#sold-tab").addClass("active");
+      $("#sold-items").addClass("active-items");
+    }
+  }
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,6 +23,7 @@
 @import "users/index";
 @import "users/edit";
 @import "users/logout";
+@import "users/sell_items";
 
 @import "sign-up/sign-up";
 @import "sign-up/login";

--- a/app/assets/stylesheets/users/_sell_items.scss
+++ b/app/assets/stylesheets/users/_sell_items.scss
@@ -1,0 +1,85 @@
+.user-sell-items-page{
+  @include height_width(100%, 100%);
+  background-color: $main_back_color;
+  padding-top: 40px;
+  .inner-container{
+    width: 1020px;
+    margin: 0 auto;
+    font-family: $main-font;
+    @include flexbox_space-between;
+    .sell-list{
+      @include height_width(100%, 700px);
+      background-color: #FFF;
+      &__title{
+        @include string-set(16ox, bold, #333333);
+        padding: 0 16px;
+        line-height: 72px;
+      }
+      &__tabs{
+        display: flex;
+        text-align: center;
+        &__tab{
+          display: block;
+          width: 50%;
+          line-height: 72px;
+          background-color: #EEE;
+          @include string-set(16ox, bold, #333333);
+          &:hover{
+            color: #888888;
+          }
+        }
+        .active{
+          border-top: 2px solid $main-color;
+          background-color: #FFF;
+        }
+      }
+      .active-items{
+        display: block;
+        .item{
+          padding: 16px;
+          @include flexbox_space-between;
+          border-bottom: 1px solid $main_back_color;
+          &__left{
+            &__img{
+              float: left;
+              img{
+                @include height_width(48px, 48px);
+              }
+            }
+            &__info{
+              margin-left: 16px;
+              float: left;
+              &__top{
+                @include string-set(14ox, normal, #333333);
+              }
+              &__bottom{
+                margin-top: 8px;
+               &__icon{
+                @include string-set(14ox, normal, #888888);
+                margin-right: 6px;
+               }
+              }
+            }
+          }
+          &__right{
+            position: relative;
+            .icon-arrow-right {
+              position: absolute;
+              top: 50%;
+              right: 8px;
+              color: #333333;
+              font-size: 22px;
+              transform: translate(0, -50%);
+            }
+          }
+          &:hover{
+            background-color: $light_gray;
+          }
+        }
+      }
+      &__items{
+        display: none;
+      }
+    }
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [:edit, :update]
+  before_action :set_user, only: [:edit, :update, :selling_items, :sold_items]
 
   def index
 
@@ -21,9 +21,13 @@ class UsersController < ApplicationController
 
   end
 
+  def selling_items
+    @selling_items = @user.items.where(status: 0)
+  end
 
-
-
+  def sold_items
+    @sold_items = @user.items.where(status: 1)
+  end
 
   private
 
@@ -32,7 +36,7 @@ class UsersController < ApplicationController
   end
 
   def set_user
-    @user =User.find(params[:id])
+    @user = User.find(current_user.id)
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [:edit, :update, :selling_items, :sold_items]
+  before_action :set_user, only: [:edit, :update]
 
   def index
 
@@ -22,11 +22,11 @@ class UsersController < ApplicationController
   end
 
   def selling_items
-    @selling_items = @user.items.where(status: 0)
+    @selling_items = current_user.items.where(status: 0)
   end
 
   def sold_items
-    @sold_items = @user.items.where(status: 1)
+    @sold_items = current_user.items.where(status: 1)
   end
 
   private
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
   end
 
   def set_user
-    @user = User.find(current_user.id)
+    @user = User.find(params[:id])
   end
 
 end

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -18,7 +18,7 @@
           いいね！一覧
           = icon 'fas','angle-right', class: 'icon-arrow-right'
       %li
-        = link_to  "#", class: "mypage-nav-list-item" do
+        = link_to selling_items_users_path, class: "mypage-nav-list-item" do
           出品した商品-出品中
           = icon 'fas','angle-right', class: 'icon-arrow-right'
       %li
@@ -26,7 +26,7 @@
           出品した商品-取引中
           = icon 'fas','angle-right', class: 'icon-arrow-right'
       %li
-        = link_to  "#", class: "mypage-nav-list-item" do
+        = link_to sold_items_users_path, class: "mypage-nav-list-item" do
           出品した商品-売却済み
           = icon 'fas','angle-right', class: 'icon-arrow-right'
       %li

--- a/app/views/users/sell_item/_items.html.haml
+++ b/app/views/users/sell_item/_items.html.haml
@@ -1,0 +1,18 @@
+- items.each do |item|
+  = link_to "#" do
+    %li.item
+      .item__left
+        .item__left__img
+          = image_tag item.item_images[0].image.to_s
+        .item__left__info
+          .item__left__info__top
+            = item.name
+          .item__left__info__bottom
+            %span.item__left__info__bottom__icon
+              = icon 'far', 'heart'
+              0
+            %span.item__left__info__bottom__icon
+              = icon 'far', 'comment'
+              0
+      .item__right
+        = icon 'fas', 'angle-right', class: 'icon-arrow-right'

--- a/app/views/users/sell_item/_list.html.haml
+++ b/app/views/users/sell_item/_list.html.haml
@@ -1,0 +1,18 @@
+.user-sell-items-page
+  .inner-container
+    = render partial: "shared/side_bar"
+    .sell-list
+      .sell-list__title
+        出品した商品
+      %ul.sell-list__tabs
+        = link_to selling_items_users_path, class: "sell-list__tabs__tab", id: "selling-tab" do
+          %li
+            出品中
+        = link_to sold_items_users_path, class: "sell-list__tabs__tab", id: "sold-tab" do
+          %li
+            売却済み
+      %ul#selling-items.sell-list__items
+        = render partial: "users/sell_item/items", locals: { items: items }
+      %ul#sold-items.sell-list__items
+        = render partial: "users/sell_item/items", locals: { items: items }
+        

--- a/app/views/users/selling_items.html.haml
+++ b/app/views/users/selling_items.html.haml
@@ -1,0 +1,1 @@
+= render 'users/sell_item/list', { items: @selling_items }

--- a/app/views/users/sold_items.html.haml
+++ b/app/views/users/sold_items.html.haml
@@ -1,0 +1,1 @@
+= render 'users//sell_item/list', { items: @sold_items }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update] do
     collection do
       get 'logout'
+      get 'selling_items'
+      get 'sold_items'
     end
   end
-  
   resources :registers, only: [:new]
 end


### PR DESCRIPTION
# What
＜概要＞
ログインユーザが出品してる商品一覧を表示する画面を作成
＜内容＞
(フロント)
　商品一覧を表示するためのマークアップを実施。
　出品中と売却済みでそれぞれViewを作成し、
　共通部分は部分テンプレートで共通化。
　JSではURLから判断し、出品中と売却済みの
　タブの出し分けを行えるよう記述。
(サーバ)
　出品中と売却済みでそれぞれコントローラを作成。
　statusの値によって取得する出品中と売却済みの商品を
　それぞれ取得できるよう記述。

# Why
今週のスプリントでは基本動作を目的とするため、
DBの値を正常に表示できる最低限の機能を実装。

# View Capture
<img width="1189" alt="ユーザ出品一覧画面" src="https://user-images.githubusercontent.com/56626222/69900496-791b5a00-13b7-11ea-987f-59890456a8aa.png">

参考URL
https://www.mercari.com/jp/mypage/listings/listing/