### PR TITLE
電話番号のバリデーション

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -12,7 +12,7 @@ class SignupController < ApplicationController
   end
 
   def address
-    session[:tel_no] = user_params[:tel_no]
+    
     @user = User.new
     @user.build_send_address
     #usend_addressモデルと関連付ける。
@@ -56,6 +56,23 @@ class SignupController < ApplicationController
     # 仮で作成したインスタンスのバリデーションチェックを行う.
     # 仮のインスタンスを作成しないとバリデーションが通らないため
     render '/signup/member_info' unless @user.valid?
+  end
+
+  def validates_tel_no
+    session[:tel_no] = user_params[:tel_no]
+    @user = User.new(
+      nickname:        session[:nickname],
+      email:           session[:email],
+      password:        session[:password],
+      kanji_last_name: session[:kanji_last_name],
+      kanji_first_name:session[:kanji_first_name],
+      kana_last_name:  session[:kana_last_name],
+      kana_first_name: session[:kana_first_name],
+      birth_day:       session[:birth_day],
+      tel_no:          session[:tel_no]
+    )
+
+    render '/signup/tel_no' unless @user.valid?
   end
 
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,6 @@ class User < ApplicationRecord
   validates :kana_first_name,   presence: true,on: :validates_member_info
   validates :kana_first_name,   kana: true, allow_blank: true,on: :validates_member_info
   validates :birth_day,         presence: true,on: :validates_member_info
-  validates :tel_no,            presence: true,on: :validates_member_tel_no
-  validates :tel_no,            format: {with: /\A\d{10,11}\z/}, allow_blank: true,on: :validates_tel_no
+  validates :tel_no,            presence: true
+  validates :tel_no,            format: {with:/\A\d{10}\z|\A\d{11}\z/}, allow_blank: true
 end

--- a/app/views/signup/tel_no.html.haml
+++ b/app/views/signup/tel_no.html.haml
@@ -8,6 +8,10 @@
             .signup-form
               .signup-form__label 携帯電話の番号
               = f.text_field :tel_no, class:"input-default", placeholder: "携帯の電話番号を入力"
+              .error-text
+                - @user.errors.full_messages_for(:tel_no).each do |message|
+                  %div
+                    = message
               .signup-form
                 %p.signup-text 
                   本人確認のため、携帯電話のSMS(ショートメッセージサービス)を利用するして認証を行います。


### PR DESCRIPTION
# what
電話番号確認のバリデーション
エラーメッセージ の表示

# why
不正な値をDBに保存しないため。
エラー内容をユーザーに知らせるため