### PR TITLE
ユーザープロフィール編集ページのフロントサイド・サーバーサイドLv2

### DIFF
--- a/app/assets/stylesheets/modules/_mixin.scss
+++ b/app/assets/stylesheets/modules/_mixin.scss
@@ -38,6 +38,14 @@
   }
 }
 
+/* focus時、枠の色を変更 */
+@mixin focus_border_color($color){
+  &:focus{
+    outline: none;
+    border: 1px solid $color;
+  }
+}
+
 /* 必須と任意 */
 @mixin require_set{
   margin: 0 0 0 8px;

--- a/app/assets/stylesheets/users/_edit.scss
+++ b/app/assets/stylesheets/users/_edit.scss
@@ -52,11 +52,35 @@
             line-height: 1.5;
             font-size: 16px;
             box-sizing: border-box;
+            @include focus_border_color($link-color);
 
             input{
               outline: 0;
               font-family: inherit;
             }
+          }
+          
+          .error-form{
+            @include height_width(48px, 220px);
+            margin: 0 0 0 8px;
+            vertical-align: middle;
+            padding: 10px 16px 8px;
+            border-radius: 4px;
+            background: #fff;
+            line-height: 1.5;
+            font-size: 16px;
+            box-sizing: border-box;
+            border: 1px solid red;
+            @include focus_border_color($link-color);
+
+            input{
+              outline: 0;
+              font-family: inherit;
+            }
+          }
+          .error-comment {
+            @include string_set(16px, normal, red);
+            text-align: center;
           }
         }
 
@@ -76,13 +100,9 @@
             font-size: 16px;
             line-height: 1.5;
             box-sizing: border-box;
-
-            &:focus{
-              outline: none;
-              border: 1px solid $link_color;
-            }
-              
+            @include focus_border_color($link-color);
           }
+
           .btn-default {
             margin: 16px 0 0;
             display: block;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,14 +6,14 @@ class UsersController < ApplicationController
   end
 
   def edit
-
+    
   end
 
   def update
     if @user.update(user_params)
       redirect_to edit_user_path
     else
-      redirect_to edit_user_path
+      render 'edit'
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   #メールアドレス用バリデーション
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i 
 
-  validates :nickname,          presence: true,on: :validates_member_info
+  validates :nickname,          presence: true,on: :validates_member_info,on: :update
   validates :email,             presence: true,on: :validates_member_info
   validates :email,             format: { with: VALID_EMAIL_REGEX },uniqueness: true,allow_blank: true,on: :validates_member_info
   validates :password,          presence: true,on: :validates_member_info

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -4,10 +4,18 @@
       .profile__head
         プロフィール
       = form_with model: @user, local: true  do |f|
-        .setting-profile-icon
-          %figure
-            %img
-          = f.text_field :nickname, class: "input-default",placeholder: "例）たっちゃん"
+        - if @user.errors.any?
+          .setting-profile-icon
+            %figure
+              %img
+            = f.text_field :nickname, class: "error-form",placeholder: "例）たっちゃん"
+            .error-comment
+              入力して下さい。
+        - else
+          .setting-profile-icon
+            %figure
+              %img
+            = f.text_field :nickname, class: "input-default",placeholder: "例）たっちゃん"
         .setting-profile-content
           = f.text_area :profile, class: "textarea-default", placeholder: "例）こんにちは！ご覧いただきありがとうございます。気持ちよくお取引出来るよう心がけていますので、よろしくお願いします！！"
           = f.submit "変更する", class: "btn-default btn-red"

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,9 @@ module FreemarketSample63b
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
 
+    ### バリデーション実行時にdivを発生させなくする###
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
+
+  
 end


### PR DESCRIPTION
# What
・Userモデルのnicknameにバリデーションをした。
・バリデーション時にエラーメッセージが出るようにした。
・バリデーション時にHtmlにdivタグの自動追加を防ぐための記述をした。
・エラーメッセージ用にSassの変更した。
・mixinの追加した。（フォームにfocus時に枠の色を統一）

# Why
・ユーザーがマイページ編集時にnicknameを空の状態でDBに登録できないようにするため。

