### PR TITLE
商品出品ページのバリデーション設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    @item_images = ItemImage.new
     render template: 'items/new'
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,10 +6,58 @@ class Item < ApplicationRecord
   has_many :item_images, dependent: :destroy
   has_one  :purchase, dependent: :destroy
   belongs_to_active_hash :prefecture
-  belongs_to :category
+  # belongs_to :category
 
-  validates :name, presence: true
-  
+
+  NOT_NULL_MESSAGE   = "入力してください"
+  NOT_SELECT_MESSAGE = "選択してください"
+  validates :name,       presence: { message: NOT_NULL_MESSAGE }
+  validates :name,       length: { maximum: 40, message: "40 文字以下で入力してください" }, allow_blank: true
+  validates :explain,    presence: { message: NOT_NULL_MESSAGE }
+  validates :explain,    length: { maximum: 1000, message: "1000 文字以下で入力してください" }, allow_blank: true
+  validates :condition, 
+    inclusion: {in: ["新品、未使用",
+                     "未使用に近い",
+                     "目立った傷や汚れなし",
+                     "やや傷や汚れあり",
+                     "傷や汚れあり",
+                     "全体的に状態が悪い"],
+                message: NOT_SELECT_MESSAGE
+               }
+  validates :delivery_charge,
+    inclusion: {in: ["送料込み(出品者負担)",
+                     "着払い(購入者負担)"],
+                message: NOT_SELECT_MESSAGE
+               }
+  validates :delivery_method,
+    inclusion: {in: ["未定",
+                     "らくらくメルカリ便",
+                     "ゆうメール",
+                     "レターパック",
+                     "普通郵便(定形、定形外)",
+                     "クロネコヤマト",
+                     "ゆうパック",
+                     "クリックポスト",
+                     "ゆうパケット"],
+                message: NOT_SELECT_MESSAGE
+               }
+  validates :prefecture_id, 
+    numericality: {greater_than_or_equal_to: 1,
+                   less_than_or_equal_to:    47,
+                   message: NOT_SELECT_MESSAGE
+                  }
+  validates :delivery_period,
+    inclusion: {in: ["1~2日で発送",
+                     "2~3日で発送",
+                     "4~7日で発送"],
+                message: NOT_SELECT_MESSAGE
+               }
+  validates :price,
+    numericality: {greater_than_or_equal_to: 300,
+                   less_than_or_equal_to:    9999999,
+                   message: "300以上9999999以下で入力してください"
+                  }
+                  
   enum condition: {
     "---":              0,
     "新品、未使用":       1,

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -3,4 +3,6 @@ class ItemImage < ApplicationRecord
   belongs_to :item
 
   mount_uploader :image, ImageUploader
+
+  validates :image, presence: { message: "がありません" }
 end

--- a/app/views/items/_item_overview.html.haml
+++ b/app/views/items/_item_overview.html.haml
@@ -61,4 +61,4 @@
     %th.item-info__heading
       発送日の目安
     %td.item-info__data
-      = item.delivery_period_set
+      = item.delivery_period

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -18,15 +18,24 @@
                 ドラッグアンドドロップ
                 %br
                 またはクリックしてファイルをアップロード
+        .error-text
+          - @item_images.errors.full_messages_for(:image).each do |message|
+            = message
       .item-content-box
         .item-content-box__name-title
           商品名
         .item-content-box__name-input
           = f.text_field :name, class: "", value: @item.name, placeholder: "商品名（必須40文字まで）"
+        .error-text
+          - @item.errors.full_messages_for(:name).each do |message|
+            = message
         .item-content-box__explain-title
           商品説明
         .item-content-box__explain-input
           = f.text_area :explain, class: "", value: @item.explain, placeholder: "商品の説明（必須1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです"
+        .error-text
+          - @item.errors.full_messages_for(:explain).each do |message|
+            = message
       .item-detail-box
         .item-detail-box__title
           商品の詳細
@@ -41,6 +50,9 @@
               商品の状態
             .item-detail-box__select__status__pulldown
               = f.select :condition, options_for_select(Item.conditions.keys, selected: @item.condition)
+            .error-text
+              - @item.errors.full_messages_for(:condition).each do |message|
+                = message
       .item-delivery-box
         .item-delivery-box__title
           配送について
@@ -50,21 +62,33 @@
               配送料の負担
             .item-delivery-box__select__payer__pulldown
               = f.select :delivery_charge, options_for_select(Item.delivery_charges.keys, selected: @item.delivery_charge)
+            .error-text
+              - @item.errors.full_messages_for(:delivery_charge).each do |message|
+                = message
           .item-delivery-box__select__method
             .item-delivery-box__select__method__title
               配送の方法
             .item-delivery-box__select__method__pulldown
               = f.select :delivery_method, options_for_select(Item.delivery_methods.keys, selected: @item.delivery_method)
+            .error-text
+              - @item.errors.full_messages_for(:delivery_method).each do |message|
+                = message
           .item-delivery-box__select__area
             .item-delivery-box__select__area__title
               発送元の地域
             .item-delivery-box__select__area__pulldown
               = f.collection_select :prefecture_id, Prefecture.all, :id, :name, selected: @item.prefecture_id
+            .error-text
+              - @item.errors.full_messages_for(:prefecture_id).each do |message|
+                = message
           .item-delivery-box__select__period
             .item-delivery-box__select__period__title
               発送までの日数
             .item-delivery-box__select__period__pulldown
               = f.select :delivery_period, options_for_select(Item.delivery_periods.keys, selected: @item.delivery_period)
+            .error-text
+              - @item.errors.full_messages_for(:delivery_period).each do |message|
+                = message
       .item-price-box
         .item-price-box__title
           販売価格(300〜9,999,999)
@@ -75,6 +99,9 @@
             .item-price-box__set__price__value
               ¥
               = f.text_field :price, value: @item.price, placeholder: "例）300", id: "item-price"
+            .error-text
+              - @item.errors.full_messages_for(:price).each do |message|
+                = message
           %li.item-price-box__set__fee
             .item-price-box__set__fee__title
               販売手数料 (10%)

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -3,6 +3,8 @@ ja:
     models:
       user: ユーザー
       send_address: 配送元・お届け先住所の登録
+      real_address: 住所
+      item: 商品
     attributes:
       user:
         nickname:         ニックネーム
@@ -14,9 +16,6 @@ ja:
         kana_first_name:  名(カナ)
         birth_day:        誕生日
         tel_no:           電話番号
-    models:
-      real_address: 住所
-    attributes:
       real_address:
         post_code: ''
       send_address: 
@@ -30,4 +29,14 @@ ja:
         address:          番地     
         building_name:    建物名
         tel_no:           電話番号
-
+      item:
+        name:            ''
+        explain:         ''
+        condition:       ''
+        delivery_charge: ''
+        delivery_method: ''
+        delivery_period: ''
+        price:           ''
+        prefecture_id:   ''
+      item_image:
+        image:           画像


### PR DESCRIPTION
# What
商品出品ページにバリデーションを追加

# Why
不正な値をitems、item_imagesテーブルに設定できないようにし、想定外の商品登録を行わせないようにするため。

# Capture
![localhost_3001_items](https://user-images.githubusercontent.com/56626222/70234727-a182ca00-17a4-11ea-86a0-4b4e2c27db88.png)
