### PR TITLE
商品出品ページのカテゴリー設定追加

### DIFF
--- a/app/assets/javascripts/items/new.js
+++ b/app/assets/javascripts/items/new.js
@@ -99,6 +99,62 @@ $(function() {
   }
 
   /****************************************/
+  /* カテゴリーボックス出力関数               */
+  /****************************************/
+  function addCategoryBox(children, category_no) {
+    // selectboxを追加
+    let html = `<select class='select-box' name="item[category_id]" id="item_category_id${category_no}">
+                <option value="">---</option>`;
+    // 取得したcategoryレコード分プルダウンを追加
+    children.forEach(function(child){
+      html = html + `<option value=${child.id}>${child.name}</option>`;
+    });
+    // 前回のプルダウンを削除
+    $(`#item_category_id${category_no}`).remove();
+    // 親カテゴリが変更された場合、３個目のプルダウンも削除
+    if(category_no == 2){
+      $('#item_category_id3').remove();
+    }
+    // selectboxを追加
+    $(".item-detail-box__select__category__pulldown").append(html);
+  }
+  
+  function ajaxSearch(category_id, id_tag){
+    var category_no = 0;
+    // 変更があったselectboxをもとにselectboxにつけるID名を設定
+    if (id_tag == 'item_category_id') {
+      category_no = 2;
+    }
+    else if(id_tag == 'item_category_id2') {
+      category_no = 3;
+    }
+    // 非同期で子カテゴリの情報を取得
+    $.ajax({
+      type: 'GET',
+      url: '/categories/search',
+      data: { category_id: category_id },
+      dataType: 'json'
+    })
+    .done(function(children) {
+      addCategoryBox(children, category_no);
+    })
+    .fail(function() {
+      alert("通信に失敗しました");
+    });
+  }
+  // 親カテゴリが変更された場合
+  $(document).on('change', '#item_category_id', function(){
+    var category_id = $("#item_category_id").val();
+    var id_tag = $(this).attr('id');
+    ajaxSearch(category_id, id_tag);
+  });
+  // 子カテゴリが変更された場合
+  $(document).on('change', '#item_category_id2', function(){
+    var category_id = $("#item_category_id2").val();
+    var id_tag = $(this).attr('id');
+    ajaxSearch(category_id, id_tag);
+  });
+  /****************************************/
   /* 販売利益算出関数                       */
   /****************************************/
   function calcProfit() {

--- a/app/assets/stylesheets/modules/_common.scss
+++ b/app/assets/stylesheets/modules/_common.scss
@@ -34,6 +34,10 @@
   clear: both;
 }
 
+.select-box{
+  @include pull_down(100%);
+  margin-top: 8px;
+}
 .day, .month, .year {
   @include height_width(48px, 43%);
   border: 1px solid #ccc;

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -5,6 +5,14 @@ class CategoriesController < ApplicationController
 
   end
 
+  def search
+    @children = Category.find(params[:category_id]).children
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+  
   private
 
   def set_categories

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,7 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @item_images = ItemImage.new
+    @parents = Category.where(ancestry: nil)
   end
 
   def show
@@ -15,18 +16,17 @@ class ItemsController < ApplicationController
     
     item_save_result  = true
     image_save_result = true
+    @parents = Category.where(ancestry: nil)
     @item_images = ItemImage.new
     # itemsレコード保存のエラーチェック
     @item = Item.new(item_params)
     item_save_result = @item.valid?
     # item_imagesレコード保存のエラーチェック
     if params[:item_images].present?
-      @item_images = ItemImage.new(image: params[:item_images][:image][0].image,
-                                   item_id: @item.id)
-      image_save_result = @item_images.valid?
+      image_save_result = true
     else
       image_save_result = @item_images.valid?
-      end
+    end
     # itemレコード、item_imagesのバリデーションを通過した場合
     if item_save_result && image_save_result
       if @item.save
@@ -101,7 +101,8 @@ class ItemsController < ApplicationController
                   :delivery_method,
                   :prefecture_id,
                   :delivery_period,
-                  :price)
+                  :price,
+                  :category_id)
           .merge(user_id: current_user.id,
                  status: 0,
                  like_cnt: 0,

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,9 +6,7 @@ class Item < ApplicationRecord
   has_many :item_images, dependent: :destroy
   has_one  :purchase, dependent: :destroy
   belongs_to_active_hash :prefecture
-  # belongs_to :category
-
-  # accepts_nested_attributes_for :item_images
+  belongs_to :category
 
   NOT_NULL_MESSAGE   = "入力してください"
   NOT_SELECT_MESSAGE = "選択してください"

--- a/app/views/categories/search.json.jbuilder
+++ b/app/views/categories/search.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @children do |child|
+  json.id   child.id
+  json.name child.name
+end

--- a/app/views/items/_item_overview.html.haml
+++ b/app/views/items/_item_overview.html.haml
@@ -17,15 +17,15 @@
       カテゴリー
     %td.item-info__data
       = link_to "#", class: "blue-link" do
-        レディース
+        = item.category.parent.parent.name
       %br
       = link_to "#", class: "blue-link" do
         = icon 'fas', 'angle-right'
-        靴
+        = item.category.parent.name
       %br
       = link_to "#", class: "blue-link" do
         = icon 'fas', 'angle-right'
-        ハイヒール
+        = item.category.name
   %tr
     %th.item-info__heading
       ブランド

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -51,12 +51,12 @@
             .item-detail-box__select__category__title
               カテゴリー
             .item-detail-box__select__category__pulldown
-              = f.select :category, [['---', 0], ['sample', 1]]
+              = f.collection_select :category_id, @parents, :id, :name, { prompt: "---" }, {class: 'select-box'}
           .item-detail-box__select__status
             .item-detail-box__select__status__title
               商品の状態
             .item-detail-box__select__status__pulldown
-              = f.select :condition, options_for_select(Item.conditions.keys, selected: @item.condition)
+              = f.select :condition, options_for_select(Item.conditions.keys, selected: @item.condition), {}, {class: 'select-box'}
             .error-text
               - @item.errors.full_messages_for(:condition).each do |message|
                 = message
@@ -68,7 +68,7 @@
             .item-delivery-box__select__payer__title
               配送料の負担
             .item-delivery-box__select__payer__pulldown
-              = f.select :delivery_charge, options_for_select(Item.delivery_charges.keys, selected: @item.delivery_charge)
+              = f.select :delivery_charge, options_for_select(Item.delivery_charges.keys, selected: @item.delivery_charge), {}, {class: 'select-box'}
             .error-text
               - @item.errors.full_messages_for(:delivery_charge).each do |message|
                 = message
@@ -76,7 +76,7 @@
             .item-delivery-box__select__method__title
               配送の方法
             .item-delivery-box__select__method__pulldown
-              = f.select :delivery_method, options_for_select(Item.delivery_methods.keys, selected: @item.delivery_method)
+              = f.select :delivery_method, options_for_select(Item.delivery_methods.keys, selected: @item.delivery_method), {}, {class: 'select-box'}
             .error-text
               - @item.errors.full_messages_for(:delivery_method).each do |message|
                 = message
@@ -84,7 +84,7 @@
             .item-delivery-box__select__area__title
               発送元の地域
             .item-delivery-box__select__area__pulldown
-              = f.collection_select :prefecture_id, Prefecture.all, :id, :name, selected: @item.prefecture_id
+              = f.collection_select :prefecture_id, Prefecture.all, :id, :name, {selected: @item.prefecture_id}, {class: 'select-box'}
             .error-text
               - @item.errors.full_messages_for(:prefecture_id).each do |message|
                 = message
@@ -92,7 +92,7 @@
             .item-delivery-box__select__period__title
               発送までの日数
             .item-delivery-box__select__period__pulldown
-              = f.select :delivery_period, options_for_select(Item.delivery_periods.keys, selected: @item.delivery_period)
+              = f.select :delivery_period, options_for_select(Item.delivery_periods.keys, selected: @item.delivery_period), {}, {class: 'select-box'}
             .error-text
               - @item.errors.full_messages_for(:delivery_period).each do |message|
                 = message

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,9 @@ Rails.application.routes.draw do
   end
   
   resources :prefectures, only: [:show]
-  resources :categories, only: [:index]
-  
+  resources :categories, only: [:index] do
+    collection do
+      get 'search'
+    end
+  end
 end

--- a/db/migrate/20191209105144_add_details_to_items.rb
+++ b/db/migrate/20191209105144_add_details_to_items.rb
@@ -1,0 +1,5 @@
+class AddDetailsToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :category, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_06_103011) do
+ActiveRecord::Schema.define(version: 2019_12_09_105144) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -51,6 +51,10 @@ ActiveRecord::Schema.define(version: 2019_12_06_103011) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "prefecture_id", null: false
+    t.bigint "categoy_id"
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_items_on_category_id"
+    t.index ["categoy_id"], name: "index_items_on_categoy_id"
     t.index ["condition"], name: "index_items_on_condition"
     t.index ["delivery_period"], name: "index_items_on_delivery_period"
     t.index ["name"], name: "index_items_on_name"
@@ -128,6 +132,7 @@ ActiveRecord::Schema.define(version: 2019_12_06_103011) do
   end
 
   add_foreign_key "item_images", "items"
+  add_foreign_key "items", "categories"
   add_foreign_key "items", "users"
   add_foreign_key "purchases", "items"
   add_foreign_key "purchases", "users"


### PR DESCRIPTION
# What
商品出品ページにカテゴリーボックスを追加し、カテゴリ情報をitemsテーブルに保存する。
＜内容＞
（フロント）
・商品出品ページ（items/new）に親カテゴリのプルダウンを追加
・親カテゴリが選択されたらJSで紐づく子カテゴリを取得し、
　プルダウンを追加するよう実装（ajax）
・商品詳細ページ（items/show）に出品時に選択したカテゴリが表示されるよう変更
（バック）
・categories/searchアクションにてjson形式で渡されたパラメータをもとに
　子カテゴリを取得するよう実装
（DB）
・itemsテーブルにcategory_idを追加

# Why
商品にカテゴリ情報を持たせ、トップページでカテゴリの出し分けができるようにするため。

# JS動作
https://gyazo.com/5911f8b5930ddfad38175912cc369540
