### PR TITLE
ビューの修正、新規登録の不具合解消

### DIFF
--- a/app/controllers/send_address_controller.rb
+++ b/app/controllers/send_address_controller.rb
@@ -1,5 +1,6 @@
 class SendAddressController < ApplicationController
   before_action :set_user, only: [:new, :create]
+  before_action :set_categories, only: [:new]
 
   def new
     @send_address = @user.send_address
@@ -46,6 +47,10 @@ class SendAddressController < ApplicationController
     ).merge(user_id: current_user.id)
   end
 
+  def set_categories
+    @parents = Category.where(ancestry: nil)
+  end
+  
 end
 
 

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -8,6 +8,7 @@ class SignupController < ApplicationController
   def member_info
     @user = User.new 
     session["password"] = []
+    session[:tel_no] = []
   end
 
   def tel_no
@@ -32,7 +33,7 @@ class SignupController < ApplicationController
         client.api.account.messages.create(from: ENV["TWILIO_PHONE_NUMBER"], to: phone_number, body: sms_number)
       rescue
         #失敗した場合ここが動く
-        render "signup/tel_no"
+        redirect_to  tel_no_signup_index_path
         return false
       end
     else 
@@ -67,6 +68,32 @@ class SignupController < ApplicationController
 
   def address
     @send_address = SendAddress.new
+  end
+
+  def credit
+    credit_card = CreditCard.where(user_id: current_user.id)
+  end
+
+  def pay
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    if params['payjp-token'].blank?
+      render '/signup/create'
+    else
+      customer = Payjp::Customer.create(
+      description: '登録テスト',
+      card: params['payjp-token'],
+      metadata: {user_id: current_user.id}
+      ) 
+      @credit_card = CreditCard.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
+      if @credit_card.save
+        render '/signup/create'
+      else
+        redirect_to action: "pay"
+      end
+    end
+  end
+
+  def create  
   end
 
   def validates_member_info
@@ -123,32 +150,6 @@ class SignupController < ApplicationController
   def validates_address
     @send_address = SendAddress.create(send_address_params)
     render '/signup/address' unless @send_address.valid?
-  end
-
-  def credit
-    credit_card = CreditCard.where(user_id: current_user.id)
-  end
-
-  def pay
-    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-    if params['payjp-token'].blank?
-      render '/signup/create'
-    else
-      customer = Payjp::Customer.create(
-      description: '登録テスト',
-      card: params['payjp-token'],
-      metadata: {user_id: current_user.id}
-      ) 
-      @credit_card = CreditCard.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
-      if @credit_card.save
-        render '/signup/create'
-      else
-        redirect_to action: "pay"
-      end
-    end
-  end
-
-  def create  
   end
 
   def user_sesssion_set

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,7 +9,7 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
-    - if params[:controller] == "home" || params[:controller] == "users" || params[:controller] == "items" && (params[:action] == "show" || params[:action] == "own_show") || params[:controller] == "real_address" || params[:controller] == "categories"
+    - if params[:controller] == "home" || params[:controller] == "users" || params[:controller] == "items" && (params[:action] == "show" || params[:action] == "own_show") || params[:controller] == "real_address" || params[:controller] == "send_address" || params[:controller] == "categories"
       = render "shared/header"
       = yield
       = render "shared/sell_button"

--- a/app/views/send_address/new.html.haml
+++ b/app/views/send_address/new.html.haml
@@ -1,5 +1,5 @@
 %nav.bread-crumbs
-  - breadcrumb :real_address
+  - breadcrumb :send_address
   = breadcrumbs separator: " &rsaquo; "
 %main.user-edit-top
   .l-container.clearfix

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -32,6 +32,11 @@ crumb :real_address do
   parent :mypage
 end
 
+crumb :send_address do
+  link "配送元・お届け先住所の登録", new_user_send_address_path
+  parent :mypage
+end
+
 crumb :logout do
   link "ログアウト", logout_users_path
   parent :mypage


### PR DESCRIPTION
# what
ビューの崩れてところを修正
[![Image from Gyazo](https://i.gyazo.com/c202ce2490e7f521bc45fb59808a6694.png)](https://gyazo.com/c202ce2490e7f521bc45fb59808a6694)

新規登録の不具合解消
電話番号認証に失敗した後、新規登録できなくなっていた。
# why
新規登録の不具合解消
電話番号認証に失敗した後に新規登録しようとするとパスワードのところでエラー
[![Image from Gyazo](https://i.gyazo.com/33f3a3f8aca7a13e5aa44e07abda4815.png)](https://gyazo.com/33f3a3f8aca7a13e5aa44e07abda4815)
電話番号認証前の値がsessionに入ったままの状態になっている。
session[:tel_no]に値が入ったままだとセッションの情報を更新できなくなるため。
member_infoアクションが呼ばれるとき
session[:password]=[]としているため、電話番号認証に失敗した後に新規登録しようとすると
パスワードのところでエラーがでる。