### PR TITLE
パンくずリストの追加

### DIFF
--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,3 +1,6 @@
+%nav.bread-crumbs
+  - breadcrumb :category_list
+  = breadcrumbs separator: " &#12297; "
 %main.category-top
   .category
     .category__all

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,1 +1,4 @@
+%nav.bread-crumbs
+  - breadcrumb :category_title
+  = breadcrumbs separator: " &#12297; "
 = render partial: "shared/items", locals: {items: @items}

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -1,6 +1,6 @@
 %nav.bread-crumbs
   - breadcrumb :credit_cards
-  = breadcrumbs separator: " &rsaquo; "
+  = breadcrumbs separator: " &#12297; "
 %main.cards-page-new
   .l-container.clearfix
     = render "shared/side_bar" 

--- a/app/views/real_address/new.html.haml
+++ b/app/views/real_address/new.html.haml
@@ -1,6 +1,6 @@
 %nav.bread-crumbs
   - breadcrumb :real_address
-  = breadcrumbs separator: " &rsaquo; "
+  = breadcrumbs separator: " &#12297; "
 %main.l-container.clearfix
   .l-content
     %section.l-chapter-container.mypage-identification

--- a/app/views/real_address/new.html.haml
+++ b/app/views/real_address/new.html.haml
@@ -1,23 +1,14 @@
 %nav.bread-crumbs
   - breadcrumb :real_address
   = breadcrumbs separator: " &#12297; "
-%main.l-container.clearfix
-  .l-content
-    %section.l-chapter-container.mypage-identification
-      %h2.l-chapter-head
-        本人情報の登録
-      = form_with model: @realaddress, url: user_real_address_index_path, local: true, method: :post, class: "l-single-inner" do |f|
-        %div
-          %p
-            お客さまの本人情報をご登録ください。
-            %br
-            登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
-          %p.text-right
-            %a{href: "/jp/help_center/article/495/", target: "_blank"}
-              本人確認書類のアップロードについて
-              %i.fas.fa-angle-right
-          .form-group
-            %label :お名前
+%main.real-address-new-top
+  .l-container.clearfix
+    .l-content
+      %section.l-chapter-container.mypage-identification
+        %h2.l-chapter-head
+          本人情報の登録
+        = form_with model: @realaddress, url: user_real_address_index_path, local: true, method: :post, class: "l-single-inner" do |f|
+          %div
             %p
               お客さまの本人情報をご登録ください。
               %br

--- a/app/views/send_address/new.html.haml
+++ b/app/views/send_address/new.html.haml
@@ -1,6 +1,6 @@
 %nav.bread-crumbs
-  - breadcrumb :real_address
-  = breadcrumbs separator: " &rsaquo; "
+  - breadcrumb :change_address
+  = breadcrumbs separator: " &#12297; "
 %main.user-edit-top
   .l-container.clearfix
     .l-content

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,6 +1,6 @@
 %nav.bread-crumbs
   - breadcrumb :profile
-  = breadcrumbs separator: " &rsaquo; "
+  = breadcrumbs separator: " &#12297; "
 %main.user-edit-top
   .l-container.clearfix
     .l-content

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,6 +1,6 @@
 %nav.bread-crumbs
   - breadcrumb :mypage
-  = breadcrumbs separator: " &rsaquo; "
+  = breadcrumbs separator: " &#12297; "
 %main.user-mypage-top
   .l-container.clearfix
     = render "shared/side_bar"

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,6 +1,6 @@
 %nav.bread-crumbs
   - breadcrumb :logout
-  = breadcrumbs separator: " &rsaquo; "
+  = breadcrumbs separator: " &#12297; "
 %main.user-logout-top
   .l-container.clearfix
     .l-content

--- a/app/views/users/sell_item/_list.html.haml
+++ b/app/views/users/sell_item/_list.html.haml
@@ -1,11 +1,11 @@
 - if @selling_items
   %nav.bread-crumbs
     - breadcrumb :selling_items
-    = breadcrumbs separator: " &rsaquo; "
+    = breadcrumbs separator: " &#12297; "
 - else @sold_items
   %nav.bread-crumbs
     - breadcrumb :sold_items
-    = breadcrumbs separator: " &rsaquo; "
+    = breadcrumbs separator: " &#12297; "
 .user-sell-items-page
   .inner-container
     = render partial: "shared/side_bar"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,3 +1,6 @@
+%nav.bread-crumbs
+  - breadcrumb :user_page
+  = breadcrumbs separator: " &#12297; "
 %main.user-show-top
   .user-box
     .user-box__top.text-center

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,6 +2,22 @@ crumb :root do
   link "メルカリ", root_path
 end
 
+crumb :category_list do
+  link "カテゴリー一覧", categories_path
+  parent :root
+end
+
+crumb :category_title do
+  @category = Category.find(params[:id])
+  link @category.name, category_path
+  parent :category_list
+end
+
+crumb :user_page do
+  link current_user.nickname, user_path
+  parent :root
+end
+
 crumb :mypage do
   link "マイページ", users_path
   parent :root
@@ -19,6 +35,11 @@ end
 
 crumb :profile do
   link "プロフィール", edit_user_path
+  parent :mypage
+end
+
+crumb :change_address do
+  link "発送元・お届け先住所変更", new_user_send_address_path
   parent :mypage
 end
 


### PR DESCRIPTION
# What
・パンくずリストを表示できるページを追加した。
・パンくずリストの区切りの表示を修正した。

# Why
・パンくずリストがあることでサイトの閲覧者の現在位置が分かるようにする為。