### PR TITLE
パンくずリストの追加（売上・振込申請ページ）

### DIFF
--- a/app/views/users/sold_score.html.haml
+++ b/app/views/users/sold_score.html.haml
@@ -1,6 +1,6 @@
--# %nav.bread-crumbs
--#   - breadcrumb :logout
--#   = breadcrumbs separator: " &rsaquo; "
+%nav.bread-crumbs
+  - breadcrumb :sold_score
+  = breadcrumbs separator: " &#12297; "
 %main.user-sold-score-top
   .l-container.clearfix
     .l-content

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -33,6 +33,11 @@ crumb :sold_items do
   parent :mypage
 end
 
+crumb :sold_score do
+  link "売上・振込申請", sold_score_users_path
+  parent :mypage
+end
+
 crumb :profile do
   link "プロフィール", edit_user_path
   parent :mypage


### PR DESCRIPTION
# What
・売上・振込申請ページにパンくずリストを表示させる為の記述をした。

# Why
・サイトの閲覧者が、パンくずリストで現在位置が分かるようにする為。